### PR TITLE
docs: opisz wstępnie ustaloną konwencję wiadomości commit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    // use convetional commits config as a base
+    extends: ['@commitlint/config-conventional'],
+    'rules': {
+        'header-max-length': [2, 'always', 70]
+    },
+};

--- a/docs/design/CONTRIBUTE.md
+++ b/docs/design/CONTRIBUTE.md
@@ -1,0 +1,43 @@
+# Wymagania podczas pracy nad projektem
+
+## Wiadomości commitów
+
+Commity w tym projekcie korzystają ze specyfikacji [Convetional Commits w wersji 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Commity mają w skrócie następującą strukturę
+
+```
+<typ>[opcjonalnie zakres]: <opis>
+
+[opcjonalny dłuższy opis commitu]
+
+[opcjonalne stopki]
+```
+
+### Pierwsza linia wiadomości
+
+Pierwsza linia wiadomości **musi** spełniać wszystkie poniższe kryteria:
+
+- `<opis>` zaczyna się **małą literą**
+- `<opis>` **nie** jest zakończony kropką
+- `<opis>` używa trybu rozkazującego czasu teraźniejszego (dla przykładu `ustaw` a nie `ustawi` czy `ustawiono`)
+- **całość** pierwszej linii (wraz z typem i zakresem) **nie powinna przekraczać `70` znaków** 
+
+### Typy
+
+Typ jest **obowiązkowy** i powinien być wybrany z poniższej listy (ze znaczeniami zgodnymi ze [typami ze specyfikacji Angular](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)):
+
+- fix
+- feat
+- build
+- ci
+- docs
+- style
+- refactor
+- perf
+- test
+
+### Zakresy
+
+Jeśli commit dotyczy jednego z tych zakresów **należy go oznaczyć** natomiast **nie jest wymagane** jeśli zawartość commitu dotyczy **więcej niż jednego** z wymienionych zakresów lub **nie wpisuje się w żadne z nich**.
+
+- backend
+- frontned


### PR DESCRIPTION
Wydaje mi się, że ten dokument zawiera ustaloną wstępnie konwencję commitów. Jestem oczywiście otwarty na uwagi i sugestie dodatków/zmian, szczególnie w kwestii zakresów. Nie jestem przekonany czy wybrane przeze mnie będą wystarczające do końca projektu jednak, na ten moment, nie przychodzi mi nic innego do głowy. Zawsze można dodać później, to po prostu plik w repozytorium.
Wydaje mi się natomiast, że zbyt szczegółowa lista zakresów (np. dla front-endu osobno `layout`, `content` itp. a dla backendu osobno `domain`, `api`, ...) wydaje się nadmiarowe.