### PR TITLE
chore: dodaj szablon FR z dokumentacji na GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/user-story-feature-request.md
@@ -1,0 +1,38 @@
+---
+name: User Story Feature Request
+about: 'Dodaj FR w formie user story. Jeśli należy do epicu należy dodać label `Epic:
+  nazwa`.'
+title: "[USER-STORY]  {funkcja}"
+labels: enhancement
+assignees: ''
+
+---
+
+Jako {persona} chcę {funkcja} [aby {wartość-dodana-dla-persony}].
+[
+Wchodzi w skład **epica**: {nazwa-epica}.
+]
+- [ ] Jeśli zrobię {X} system powinien {Y}
+  - potencjalny opis i/lub dodatkowe "warunki" spełniania tego kryterium
+- [ ] Po {X} powinno stać się {Y}
+- [ ] Gdy stanie się {X} powinno [stać się] {Y}
+    - Lub dowolna, inna forma, to tylko sugestie formułowania kryteriów akceptacyjnych muszą one jednak być **szczegółowe** i **jednoznacznie potwierdzalne**. To czy kryterium akceptacyjne jest spełnione, **nie powinno być sprawą dyskusyjną**.
+   - Przy używaniu innej formy zalecane jest jednak zachowanie kolejności `[...] {X} [...] {Y}` gdzie **`X` jest warunkiem/sytuacją akcją użytkownika** a **`Y` reakcją/zachowaniem systemu**.
+
+[
+
+Inne, ważne do udokumentowania ograniczenia/wymóg, które nie spełniają warunków kryterium akceptacyjnego:
+1. w formie listy
+2. najlepiej numerowanej
+
+]
+
+
+## Zasoby
+
+- zewnętrzne linki powiązane przydatne do zrozumienia user stories
+- w typowym zewnętrznym zasobem są mockupy interfejsu jeśli takowe dotyczą danej historyjki
+
+## Notatki
+
+Wszystkie inne, przydatne informacje nie pasują do żadnej z innych sekcji.


### PR DESCRIPTION
Rozwiązuje punkt: "Dodanie przygotowanego szablonu jako szablonu "Issue" na platformie GitHub"(2) z issue #4. Stworzono osobny PR, ponieważ podczas tworzenia szablonu przez graficzny interfejs platformy GitHub nie można dodać go jako commitu do już istniejącej gałęzi.