### PR TITLE
build: dodaj automatyczne testy jednostkowe dla gałęzi głównej

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,26 @@
+name: Zbuduj aplikację i uruchom testy jednostkowe
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-run-tests:
+    name: Buduje aplikację i uruchamia testy jednostkowe
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Skonfiguruj .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Zainstaluj zależności
+      run: dotnet restore
+    - name: Zbuduj aplikację
+      run: dotnet build --no-restore
+    - name: Uruchom testy
+      run: dotnet test --no-build --verbosity normal

--- a/docs/design/CONTRIBUTE.md
+++ b/docs/design/CONTRIBUTE.md
@@ -92,3 +92,5 @@ W ramach tego projektu używany jest [Structurizr](https://structurizr.com/) ([d
 ### Workflowy
 
 - [Wyrenderuj diagramy Struturizr](/.github/workflows/render-structurizr-diagrams.yaml) - Renderuje diagramy, jeżeli ich źródło zostało zmienione **a pliki wyrenderowanych diagramów nie**. Preferowane jest korzystanie z narzędzia [Structurizr Lite](https://structurizr.com/help/lite) ze względu na lepszą czytelność. **UWAGA: Ręcznie wyrenderuj wszystkie zmienione diagramy, jeśli którykolwiek został wyrenderowany ręcznie.** Akcja nie jest w stanie rozróżnić, które diagramy uległy zmianie, a które nie.
+
+- [Zbuduj aplikację i uruchom testy jednostkowe](/.github/workflows/build-and-test.yaml) — Buduje wszystkie projekty i uruchamia przypisane im testy jednostkowe. Podjęto decyzję, by uruchamiać ten workflow tylko dla pull requrestów i pushy do głównej gałęzi z uwagi na to, że w workflow red-green-refactor umieszczanie testów w repozytorium, dla których kod nie został jeszcze napisany.


### PR DESCRIPTION
Użyto szablonu akcji bazującego na [zalecanym przez GitHub szablonie dla testów jednostkowych w .NET Core](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net#building-and-testing-your-code). Dodano deskryptywne nazwy dla korków dla uproszczenia diagnostyki i opisano w odpowiednim dokumencie w repozytorium.

Testy zostały dodane i sprawdzono poprawność ich działania lokalnie, przy użyciu narzędzia `act`. Nie pushuję ich do repozytorium, żeby nie "zaśmiecać" kodu projektu testami, które są zawsze akceptowane.